### PR TITLE
Replace webbrowser.open_new_tab with native sublime API call to fix browser inconsistencies

### DIFF
--- a/WordPressCodex.py
+++ b/WordPressCodex.py
@@ -10,23 +10,25 @@ import sublime
 import sublime_plugin
 
 import subprocess
-import webbrowser
+
+def OpenInBrowser(url):
+    sublime.active_window().run_command('open_url', {"url": url})
 
 def SearchWpCodexFor(text):
     url = 'http://wordpress.org/search/' + text.replace(' ','%20')
-    webbrowser.open_new_tab(url)
+    OpenInBrowser(url)
 
 def SearchQPFor(text):
     url = 'http://queryposts.com/?s=' + text.replace(' ','%20')
-    webbrowser.open_new_tab(url)
+    OpenInBrowser(url)
 
 def OpenWpFunctionReference(text):
     url = 'http://codex.wordpress.org/Function_Reference/' + text.replace(' ','%20')
-    webbrowser.open_new_tab(url)
+    OpenInBrowser(url)
 
 def OpenQPFunctionReference(text):
     url = 'http://queryposts.com/function/' + text.replace(' ','%20')
-    webbrowser.open_new_tab(url)
+    OpenInBrowser(url)
 
 class WordpressCodexOpenSelectionCommand(sublime_plugin.TextCommand):
     def run(self, edit):
@@ -45,7 +47,7 @@ class WordpressCodexSearchSelectionCommand(sublime_plugin.TextCommand):
             if selection.empty():
                 selection = self.view.word(selection)
 
-            text = self.view.substr(selection)            
+            text = self.view.substr(selection)
             SearchWpCodexFor(text)
 
 class WordpressCodexSearchFromInputCommand(sublime_plugin.WindowCommand):
@@ -79,7 +81,7 @@ class QueryPostsSearchSelectionCommand(sublime_plugin.TextCommand):
             if selection.empty():
                 selection = self.view.word(selection)
 
-            text = self.view.substr(selection)            
+            text = self.view.substr(selection)
             SearchQPFor(text)
 
 class QueryPostsSearchFromInputCommand(sublime_plugin.WindowCommand):


### PR DESCRIPTION
When using the python webbrowser module, the plug-in opens the wrong browser (Firefox instead of Chrome), on Linux.

Replacing the calls to `webbrowser.open_new_tab` with the built-in sublime API call `sublime.active_window().run_command('open_url', ...)` seems to correct this problem.
